### PR TITLE
Feature/issue 1 fix iex test

### DIFF
--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -20,7 +20,7 @@ public interface IexClient {
    *
    * @return a list of all of the stock symbols supported by IEX.
    */
-  @GetMapping("/ref-data/symbols")
+  @GetMapping("/ref-data/symbols?token=${spring.rest.iexToken}")
   List<IexSymbol> getAllSymbols();
 
   /**
@@ -29,7 +29,7 @@ public interface IexClient {
    * @param symbols stock symbols to get last traded price for.
    * @return a list of the last traded price for each of the symbols passed in.
    */
-  @GetMapping("/tops/last")
+  @GetMapping("/tops/last?token=${spring.rest.iexToken}")
   List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,7 @@ spring:
    rest:
       # this points at the local WireMock server in the test environment.
       iexBasePath: http://localhost:${wiremock.server.port}/
+      iexToken: DUMMY_TOKEN
 
 ---
 # Dev properties go here
@@ -56,7 +57,8 @@ spring:
       username: sa
       password:
    rest:
-      iexBasePath: https://api.iextrading.com/1.0
+      iexBasePath: https://cloud.iexapis.com/stable
+      iexToken: pk_ae8b192b6481419199944327ab96d015
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,7 @@ spring:
    rest:
       # this points at the local WireMock server in the test environment.
       iexBasePath: http://localhost:${wiremock.server.port}/
+      iexToken: DUMMY_TOKEN
 
 ---
 # Dev properties go here
@@ -56,7 +57,8 @@ spring:
       username: sa
       password:
    rest:
-      iexBasePath: https://api.iextrading.com/1.0
+      iexBasePath: https://cloud.iexapis.com/stable
+      iexToken: YOUR_TOKEN_HERE
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,7 +60,7 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,12 +2,12 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
-    "url" : "/tops/last?symbols=FB",
+    "url" : "/tops/last?token=DUMMY_TOKEN&symbols=FB",
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
-    "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
+    "status" : 200,
+    "jsonBody" : [{"symbol":"FB","price":186.34,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",
       "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",

--- a/src/test/resources/wiremock/mappings/mapping-symbols.json
+++ b/src/test/resources/wiremock/mappings/mapping-symbols.json
@@ -2,7 +2,7 @@
   "id": "4dc720df-b9cd-465e-a27e-68ccdb49ef31",
   "name": "ref-data_symbols",
   "request": {
-    "url": "/ref-data/symbols",
+    "url": "/ref-data/symbols?token=DUMMY_TOKEN",
     "method": "GET"
   },
   "response": {


### PR DESCRIPTION
![tests](https://user-images.githubusercontent.com/115724737/196246763-c85e7c52-e68c-451d-83b0-b6286d4777b6.PNG)
All IexRestControllerTest tests passed.

![client](https://user-images.githubusercontent.com/115724737/196246770-e372ff78-29e5-4514-bd7a-030269b192a3.PNG)
Both endpoints for IEX feignClient updated to follow the new API format (requiring token).

![symbols](https://user-images.githubusercontent.com/115724737/196246767-6a6f8b7c-875b-444a-9cde-856bec5b6d0f.PNG)
![tops](https://user-images.githubusercontent.com/115724737/196246774-71f01527-1639-44a9-bedd-fd8d39596016.PNG)
Wiremocks for both ref-data/symbols and tops/last updated to follow new IEX API format (requiring token).