### PR TITLE
Feature/issue 2 switch api

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,20 +9,24 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -30,6 +34,24 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="target/generated-sources/protobuf/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="target/generated-sources/protobuf/grpc-java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/proto">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/.idea/runConfigurations/Tests_All.xml
+++ b/.idea/runConfigurations/Tests_All.xml
@@ -7,7 +7,10 @@
     <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-Dapplication.name=my-fuse-app -Dserver.port=8080 -Dapplication.log-dir=$PROJECT_DIR$/../../../../${USERNAME}/logs -Dapplication.log-archive-root-dir=$PROJECT_DIR$/../../../../${USERNAME}/logs/archive" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+    <envs>
+      <env name="token" value="d3mkul9r01qmso34a8jgd3mkul9r01qmso34a8k0" />
+    </envs>
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Unit_Tests.xml
+++ b/.idea/runConfigurations/Unit_Tests.xml
@@ -1,28 +1,24 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Unit Tests" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="fuse-starter-java" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.galatea.starter.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="fuse-starter-java" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="org.galatea.starter" />
     <option name="MAIN_CLASS_NAME" value="org.galatea.starter.UnitTestRunner" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-Dapplication.name=my-fuse-app -Dserver.port=8080 -Dapplication.log-dir=logs -Dapplication.log-archive-root-dir=logs/archive" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+    <envs>
+      <env name="token" value="d3mkul9r01qmso34a8jgd3mkul9r01qmso34a8k0" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,6 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
+encoding//src/main/proto=UTF-8
 encoding//src/main/resources=UTF-8
 encoding//src/test/java=UTF-8
 encoding//src/test/resources=UTF-8

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.methodParameters=generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=11

--- a/src/main/java/org/galatea/starter/ApiKeyRequestInterceptor.java
+++ b/src/main/java/org/galatea/starter/ApiKeyRequestInterceptor.java
@@ -1,0 +1,25 @@
+package org.galatea.starter;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+
+
+@Slf4j
+public class ApiKeyRequestInterceptor implements RequestInterceptor {
+
+  public final String apiKey;
+  public ApiKeyRequestInterceptor(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  @Override
+  public void apply(RequestTemplate template) {
+    // Instead of injecting API key into the header, inject into the query
+    // Finnhub API format is ?token=<API_KEY>
+    template.query("token", apiKey);
+  }
+
+}
+

--- a/src/main/java/org/galatea/starter/AppConfig.java
+++ b/src/main/java/org/galatea/starter/AppConfig.java
@@ -28,7 +28,7 @@ public class AppConfig {
 
   @Bean
   public RequestInterceptor apiKeyRequestInterceptor() {
-    return new ApiKeyRequestInterceptor("SecretAPIKEY");
+    return new ApiKeyRequestInterceptor(apiKey);
   }
 
   /**

--- a/src/main/java/org/galatea/starter/AppConfig.java
+++ b/src/main/java/org/galatea/starter/AppConfig.java
@@ -1,6 +1,7 @@
 package org.galatea.starter;
 
 import feign.Logger;
+import feign.RequestInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.aspect4log.aspect.LogAspect;
 import org.galatea.starter.domain.SettlementMission;
@@ -22,6 +23,13 @@ import org.springframework.core.io.ClassPathResource;
 @EnableCaching
 @EnableFeignClients
 public class AppConfig {
+  @Value("${spring.apikey}")
+  private String apiKey;
+
+  @Bean
+  public RequestInterceptor apiKeyRequestInterceptor() {
+    return new ApiKeyRequestInterceptor("SecretAPIKEY");
+  }
 
   /**
    * Create a LogAspect for use with the SpringAOP @Log annotation.

--- a/src/main/java/org/galatea/starter/domain/FinnhubLastTradedPrice.java
+++ b/src/main/java/org/galatea/starter/domain/FinnhubLastTradedPrice.java
@@ -7,11 +7,12 @@ import lombok.Data;
 @Data
 @Builder
 public class FinnhubLastTradedPrice {
-  private String currency;
-  private String description;
-  private String displaySymbol;
-  private String figi;
-  private String mic;
-  private String symbol;
-  private String type;
+  private float c;
+  private float d;
+  private float dp;
+  private float h;
+  private float l;
+  private float o;
+  private float pc;
+  private float t;
 }

--- a/src/main/java/org/galatea/starter/domain/FinnhubLastTradedPrice.java
+++ b/src/main/java/org/galatea/starter/domain/FinnhubLastTradedPrice.java
@@ -1,0 +1,17 @@
+package org.galatea.starter.domain;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FinnhubLastTradedPrice {
+  private String currency;
+  private String description;
+  private String displaySymbol;
+  private String figi;
+  private String mic;
+  private String symbol;
+  private String type;
+}

--- a/src/main/java/org/galatea/starter/domain/FinnhubSymbol.java
+++ b/src/main/java/org/galatea/starter/domain/FinnhubSymbol.java
@@ -1,0 +1,19 @@
+package org.galatea.starter.domain;
+
+import java.util.Date;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FinnhubSymbol {
+
+  private String currency;
+  private String description;
+  private String displaySymbol;
+  private String figi;
+  private String mic;
+  private String symbol;
+  private String type;
+
+}

--- a/src/main/java/org/galatea/starter/domain/IexSymbol.java
+++ b/src/main/java/org/galatea/starter/domain/IexSymbol.java
@@ -1,18 +1,18 @@
-package org.galatea.starter.domain;
-
-import java.util.Date;
-import lombok.Builder;
-import lombok.Data;
-
-@Data
-@Builder
-public class IexSymbol {
-
-  private String symbol;
-  private String name;
-  private Date date;
-  private boolean isEnabled;
-  private String type;
-  private String iexId;
-
-}
+//package org.galatea.starter.domain;
+//
+//import java.util.Date;
+//import lombok.Builder;
+//import lombok.Data;
+//
+//@Data
+//@Builder
+//public class IexSymbol {
+//
+//  private String symbol;
+//  private String name;
+//  private Date date;
+//  private boolean isEnabled;
+//  private String type;
+//  private String iexId;
+//
+//}

--- a/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
@@ -1,0 +1,51 @@
+package org.galatea.starter.entrypoint;
+
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.sf.aspect4log.Log;
+import net.sf.aspect4log.Log.Level;
+import org.galatea.starter.domain.FinnhubLastTradedPrice;
+import org.galatea.starter.domain.FinnhubSymbol;
+import org.galatea.starter.service.FinnhubService;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Log(enterLevel = Level.INFO, exitLevel = Level.INFO)
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class FinnhubRestController {
+
+  @NonNull
+  private FinnhubService finnhubService;
+
+  /**
+   * Exposes an endpoint to get all of the symbols available on Finnhub.
+   *
+   * @return a list of all Finnhub Symbols.
+   */
+  @GetMapping(value = "${mvc.finnhub.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
+  public List<FinnhubSymbol> getAllStockSymbols() {
+    return finnhubService.getAllSymbols();
+  }
+
+  /**
+   * Get the last traded price for each of the symbols passed in.
+   *
+   * @param symbols list of symbols to get last traded price for.
+   * @return a List of IexLastTradedPrice objects for the given symbols.
+   */
+  @GetMapping(value = "${mvc.finnhub.getLastTradedPricePath}", produces = {
+      MediaType.APPLICATION_JSON_VALUE})
+  public List<FinnhubLastTradedPrice> getLastTradedPrice(
+      @RequestParam(value = "symbols") final List<String> symbols) {
+    return finnhubService.getLastTradedPriceForSymbols(symbols);
+  }
+
+}

--- a/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
@@ -26,13 +26,18 @@ public class FinnhubRestController {
   private FinnhubService finnhubService;
 
   /**
-   * Exposes an endpoint to get all of the symbols available on Finnhub.
+   * Exposes an endpoint to get all symbols on Finnhub.
    *
    * @return a list of all Finnhub Symbols.
    */
   @GetMapping(value = "${mvc.finnhub.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
-  public List<FinnhubSymbol> getAllStockSymbols() {
-    return finnhubService.getAllSymbols();
+  public List<FinnhubSymbol> getAllStockSymbols(
+      @RequestParam String exchange,
+      @RequestParam(required = false) String mic,
+      @RequestParam(required = false) String figi,
+      @RequestParam(required = false) String currency
+  ) {
+    return finnhubService.getAllSymbols(exchange, mic, figi, currency);
   }
 
   /**

--- a/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/FinnhubRestController.java
@@ -44,7 +44,7 @@ public class FinnhubRestController {
   @GetMapping(value = "${mvc.finnhub.getLastTradedPricePath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<FinnhubLastTradedPrice> getLastTradedPrice(
-      @RequestParam(value = "symbols") final List<String> symbols) {
+      @RequestParam(value = "symbol") final List<String> symbols) {
     return finnhubService.getLastTradedPriceForSymbols(symbols);
   }
 

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -1,51 +1,51 @@
-package org.galatea.starter.entrypoint;
-
-import java.util.List;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import net.sf.aspect4log.Log;
-import net.sf.aspect4log.Log.Level;
-import org.galatea.starter.domain.IexLastTradedPrice;
-import org.galatea.starter.domain.IexSymbol;
-import org.galatea.starter.service.IexService;
-import org.springframework.http.MediaType;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-@Slf4j
-@Log(enterLevel = Level.INFO, exitLevel = Level.INFO)
-@Validated
-@RestController
-@RequiredArgsConstructor
-public class IexRestController {
-
-  @NonNull
-  private IexService iexService;
-
-  /**
-   * Exposes an endpoint to get all of the symbols available on IEX.
-   *
-   * @return a list of all IexStockSymbols.
-   */
-  @GetMapping(value = "${mvc.iex.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
-  public List<IexSymbol> getAllStockSymbols() {
-    return iexService.getAllSymbols();
-  }
-
-  /**
-   * Get the last traded price for each of the symbols passed in.
-   *
-   * @param symbols list of symbols to get last traded price for.
-   * @return a List of IexLastTradedPrice objects for the given symbols.
-   */
-  @GetMapping(value = "${mvc.iex.getLastTradedPricePath}", produces = {
-      MediaType.APPLICATION_JSON_VALUE})
-  public List<IexLastTradedPrice> getLastTradedPrice(
-      @RequestParam(value = "symbols") final List<String> symbols) {
-    return iexService.getLastTradedPriceForSymbols(symbols);
-  }
-
-}
+//package org.galatea.starter.entrypoint;
+//
+//import java.util.List;
+//import lombok.NonNull;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import net.sf.aspect4log.Log;
+//import net.sf.aspect4log.Log.Level;
+//import org.galatea.starter.domain.IexLastTradedPrice;
+//import org.galatea.starter.domain.IexSymbol;
+//import org.galatea.starter.service.IexService;
+//import org.springframework.http.MediaType;
+//import org.springframework.validation.annotation.Validated;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.RequestParam;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@Slf4j
+//@Log(enterLevel = Level.INFO, exitLevel = Level.INFO)
+//@Validated
+//@RestController
+//@RequiredArgsConstructor
+//public class IexRestController {
+//
+//  @NonNull
+//  private IexService iexService;
+//
+//  /**
+//   * Exposes an endpoint to get all of the symbols available on IEX.
+//   *
+//   * @return a list of all IexStockSymbols.
+//   */
+//  @GetMapping(value = "${mvc.iex.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
+//  public List<IexSymbol> getAllStockSymbols() {
+//    return iexService.getAllSymbols();
+//  }
+//
+//  /**
+//   * Get the last traded price for each of the symbols passed in.
+//   *
+//   * @param symbols list of symbols to get last traded price for.
+//   * @return a List of IexLastTradedPrice objects for the given symbols.
+//   */
+//  @GetMapping(value = "${mvc.iex.getLastTradedPricePath}", produces = {
+//      MediaType.APPLICATION_JSON_VALUE})
+//  public List<IexLastTradedPrice> getLastTradedPrice(
+//      @RequestParam(value = "symbols") final List<String> symbols) {
+//    return iexService.getLastTradedPriceForSymbols(symbols);
+//  }
+//
+//}

--- a/src/main/java/org/galatea/starter/service/FinnhubClient.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubClient.java
@@ -8,26 +8,29 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
- * A Feign Declarative REST Client to access endpoints from the Free and Open IEX API to get market
- * data. See https://iextrading.com/developer/docs/
+ * A Feign Declarative REST Client to access endpoints from the Finnhub API to get market
+ * data. See https://finnhub.io/docs/api/introduction
  */
 @FeignClient(name = "FINNHUB", url = "${spring.rest.finnhubBasePath}")
 public interface FinnhubClient {
 
   /**
-   * ?????? Rewrite this when I know what's going on
-   * Get a list of all stocks supported by IEX. See https://iextrading.com/developer/docs/#symbols.
-   * As of July 2019 this returns almost 9,000 symbols, so maybe don't call it in a loop.
+   * Get a list of all stocks supported by Finnhub. See https://finnhub.io/docs/api/stock-symbols.
+   * Constant polling is not recommended - use websocket if you need real-time updates.
    *
-   * @return a list of all of the stock symbols supported by IEX.
+   * @return a list of all stock symbols supported by Finnhub.
    */
-  @GetMapping("/ref-data/symbols")
+  @GetMapping("/ref-data/symbol")
 
-  List<FinnhubSymbol> getAllSymbols();
+  List<FinnhubSymbol> getAllSymbols(
+      @RequestParam("exchange") String exchange,
+      @RequestParam(value = "mic", required = false) String mic,
+      @RequestParam(value = "figi", required = false) String figi,
+      @RequestParam(value = "currency", required = false) String currency
+  );
 
   /**
-   * ????? Rewrite this when I know what's going on
-   * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
+   * Get the last traded price for each stock symbol passed in. See https://finnhub.io/docs/api/quote.
    *
    * @param symbols stock symbols to get last traded price for.
    * @return a list of the last traded price for each of the symbols passed in.

--- a/src/main/java/org/galatea/starter/service/FinnhubClient.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubClient.java
@@ -1,0 +1,38 @@
+package org.galatea.starter.service;
+
+import java.util.List;
+import org.galatea.starter.domain.FinnhubLastTradedPrice;
+import org.galatea.starter.domain.FinnhubSymbol;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * A Feign Declarative REST Client to access endpoints from the Free and Open IEX API to get market
+ * data. See https://iextrading.com/developer/docs/
+ */
+@FeignClient(name = "FINNHUB", url = "${spring.rest.finnhubBasePath}")
+public interface FinnhubClient {
+
+  /**
+   * ?????? Rewrite this when I know what's going on
+   * Get a list of all stocks supported by IEX. See https://iextrading.com/developer/docs/#symbols.
+   * As of July 2019 this returns almost 9,000 symbols, so maybe don't call it in a loop.
+   *
+   * @return a list of all of the stock symbols supported by IEX.
+   */
+  @GetMapping("/ref-data/symbols")
+
+  List<FinnhubSymbol> getAllSymbols();
+
+  /**
+   * ????? Rewrite this when I know what's going on
+   * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
+   *
+   * @param symbols stock symbols to get last traded price for.
+   * @return a list of the last traded price for each of the symbols passed in.
+   */
+  @GetMapping("/tops/last")
+  List<FinnhubLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
+
+}

--- a/src/main/java/org/galatea/starter/service/FinnhubClient.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubClient.java
@@ -33,6 +33,6 @@ public interface FinnhubClient {
    * @return a list of the last traded price for each of the symbols passed in.
    */
   @GetMapping("/tops/last")
-  List<FinnhubLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
+  List<FinnhubLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbol") String[] symbols);
 
 }

--- a/src/main/java/org/galatea/starter/service/FinnhubService.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubService.java
@@ -1,0 +1,49 @@
+package org.galatea.starter.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.galatea.starter.domain.FinnhubLastTradedPrice;
+import org.galatea.starter.domain.FinnhubSymbol;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * A layer for transformation, aggregation, and business required when retrieving data from IEX.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinnhubService {
+
+  @NonNull
+  private FinnhubClient finnhubClient;
+
+
+  /**
+   * Get all stock symbols from IEX.
+   *
+   * @return a list of all Stock Symbols from IEX.
+   */
+  public List<FinnhubSymbol> getAllSymbols() {
+    return finnhubClient.getAllSymbols();
+  }
+
+  /**
+   * Get the last traded price for each Symbol that is passed in.
+   *
+   * @param symbols the list of symbols to get a last traded price for.
+   * @return a list of last traded price objects for each Symbol that is passed in.
+   */
+  public List<FinnhubLastTradedPrice> getLastTradedPriceForSymbols(final List<String> symbols) {
+    if (CollectionUtils.isEmpty(symbols)) {
+      return Collections.emptyList();
+    } else {
+      return finnhubClient.getLastTradedPriceForSymbols(symbols.toArray(new String[0]));
+    }
+  }
+
+
+}

--- a/src/main/java/org/galatea/starter/service/FinnhubService.java
+++ b/src/main/java/org/galatea/starter/service/FinnhubService.java
@@ -7,8 +7,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.galatea.starter.domain.FinnhubLastTradedPrice;
 import org.galatea.starter.domain.FinnhubSymbol;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * A layer for transformation, aggregation, and business required when retrieving data from IEX.
@@ -23,12 +26,19 @@ public class FinnhubService {
 
 
   /**
-   * Get all stock symbols from IEX.
+   * Get all stock symbols from Finnhub for the exchange code given
    *
-   * @return a list of all Stock Symbols from IEX.
+   * @return a list of all Stock Symbols from Finnhub.
    */
-  public List<FinnhubSymbol> getAllSymbols() {
-    return finnhubClient.getAllSymbols();
+
+  @GetMapping(value = "${mvc.finnhub.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
+  public List<FinnhubSymbol> getAllSymbols(
+      @RequestParam String exchange,
+      @RequestParam(required = false) String mic,
+      @RequestParam(required = false) String figi,
+      @RequestParam(required = false) String currency
+  ) {
+    return finnhubClient.getAllSymbols(exchange, mic, figi, currency);
   }
 
   /**

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,35 +1,35 @@
-package org.galatea.starter.service;
-
-import java.util.List;
-import org.galatea.starter.domain.IexLastTradedPrice;
-import org.galatea.starter.domain.IexSymbol;
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
-/**
- * A Feign Declarative REST Client to access endpoints from the Free and Open IEX API to get market
- * data. See https://iextrading.com/developer/docs/
- */
-@FeignClient(name = "IEX", url = "${spring.rest.iexBasePath}")
-public interface IexClient {
-
-  /**
-   * Get a list of all stocks supported by IEX. See https://iextrading.com/developer/docs/#symbols.
-   * As of July 2019 this returns almost 9,000 symbols, so maybe don't call it in a loop.
-   *
-   * @return a list of all of the stock symbols supported by IEX.
-   */
-  @GetMapping("/ref-data/symbols")
-  List<IexSymbol> getAllSymbols();
-
-  /**
-   * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
-   *
-   * @param symbols stock symbols to get last traded price for.
-   * @return a list of the last traded price for each of the symbols passed in.
-   */
-  @GetMapping("/tops/last")
-  List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
-
-}
+//package org.galatea.starter.service;
+//
+//import java.util.List;
+//import org.galatea.starter.domain.IexLastTradedPrice;
+//import org.galatea.starter.domain.IexSymbol;
+//import org.springframework.cloud.openfeign.FeignClient;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.RequestParam;
+//
+///**
+// * A Feign Declarative REST Client to access endpoints from the Free and Open IEX API to get market
+// * data. See https://iextrading.com/developer/docs/
+// */
+//@FeignClient(name = "IEX", url = "${spring.rest.iexBasePath}")
+//public interface IexClient {
+//
+//  /**
+//   * Get a list of all stocks supported by IEX. See https://iextrading.com/developer/docs/#symbols.
+//   * As of July 2019 this returns almost 9,000 symbols, so maybe don't call it in a loop.
+//   *
+//   * @return a list of all of the stock symbols supported by IEX.
+//   */
+//  @GetMapping("/ref-data/symbols")
+//  List<IexSymbol> getAllSymbols();
+//
+//  /**
+//   * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
+//   *
+//   * @param symbols stock symbols to get last traded price for.
+//   * @return a list of the last traded price for each of the symbols passed in.
+//   */
+//  @GetMapping("/tops/last")
+//  List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
+//
+//}

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -1,49 +1,49 @@
-package org.galatea.starter.service;
-
-import java.util.Collections;
-import java.util.List;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.galatea.starter.domain.IexLastTradedPrice;
-import org.galatea.starter.domain.IexSymbol;
-import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
-
-/**
- * A layer for transformation, aggregation, and business required when retrieving data from IEX.
- */
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class IexService {
-
-  @NonNull
-  private IexClient iexClient;
-
-
-  /**
-   * Get all stock symbols from IEX.
-   *
-   * @return a list of all Stock Symbols from IEX.
-   */
-  public List<IexSymbol> getAllSymbols() {
-    return iexClient.getAllSymbols();
-  }
-
-  /**
-   * Get the last traded price for each Symbol that is passed in.
-   *
-   * @param symbols the list of symbols to get a last traded price for.
-   * @return a list of last traded price objects for each Symbol that is passed in.
-   */
-  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final List<String> symbols) {
-    if (CollectionUtils.isEmpty(symbols)) {
-      return Collections.emptyList();
-    } else {
-      return iexClient.getLastTradedPriceForSymbols(symbols.toArray(new String[0]));
-    }
-  }
-
-
-}
+//package org.galatea.starter.service;
+//
+//import java.util.Collections;
+//import java.util.List;
+//import lombok.NonNull;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.galatea.starter.domain.IexLastTradedPrice;
+//import org.galatea.starter.domain.IexSymbol;
+//import org.springframework.stereotype.Service;
+//import org.springframework.util.CollectionUtils;
+//
+///**
+// * A layer for transformation, aggregation, and business required when retrieving data from IEX.
+// */
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//public class IexService {
+//
+//  @NonNull
+//  private IexClient iexClient;
+//
+//
+//  /**
+//   * Get all stock symbols from IEX.
+//   *
+//   * @return a list of all Stock Symbols from IEX.
+//   */
+//  public List<IexSymbol> getAllSymbols() {
+//    return iexClient.getAllSymbols();
+//  }
+//
+//  /**
+//   * Get the last traded price for each Symbol that is passed in.
+//   *
+//   * @param symbols the list of symbols to get a last traded price for.
+//   * @return a list of last traded price objects for each Symbol that is passed in.
+//   */
+//  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final List<String> symbols) {
+//    if (CollectionUtils.isEmpty(symbols)) {
+//      return Collections.emptyList();
+//    } else {
+//      return iexClient.getLastTradedPriceForSymbols(symbols.toArray(new String[0]));
+//    }
+//  }
+//
+//
+//}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,12 +16,18 @@ spring:
          ddl-auto: update
       database-platform: org.hibernate.dialect.MySQL5Dialect
 
+   apikey: ${token}
+
 mvc:
    settleMissionPath: /settlementEngine
    updateMissionPath: /settlementEngine/mission/
    getMissionPath: /settlementEngine/mission/
    getMissionsPath: /settlementEngine/missions
    deleteMissionPath: /settlementEngine/mission/
+   finnhub:
+     getAllSymbolsPath: /finnhub/stock/symbol
+     getLastTradedPricePath: /finnhub/quote
+
    iex:
       getAllSymbolsPath: /iex/symbols
       getLastTradedPricePath: /iex/lastTradedPrice
@@ -47,6 +53,9 @@ spring:
    rest:
       # this points at the local WireMock server in the test environment.
       iexBasePath: http://localhost:${wiremock.server.port}/
+      finnhubBasePath: http://localhost:${wiremock.server.port}/
+
+   apikey: ${token}
 
 ---
 # Dev properties go here
@@ -57,6 +66,8 @@ spring:
       password:
    rest:
       iexBasePath: https://api.iextrading.com/1.0
+      finnhubBasePath: https://finnhub.io/api/v1
+   apikey: ${token}
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,12 +25,12 @@ mvc:
    getMissionsPath: /settlementEngine/missions
    deleteMissionPath: /settlementEngine/mission/
    finnhub:
-     getAllSymbolsPath: /finnhub/stock/symbol
-     getLastTradedPricePath: /finnhub/quote
+     getAllSymbolsPath: /stock/symbol
+     getLastTradedPricePath: /quote
 
-   iex:
-      getAllSymbolsPath: /iex/symbols
-      getLastTradedPricePath: /iex/lastTradedPrice
+#   iex:
+#      getAllSymbolsPath: /iex/symbols
+#      getLastTradedPricePath: /iex/lastTradedPrice
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5
@@ -52,7 +52,7 @@ spring:
       password:
    rest:
       # this points at the local WireMock server in the test environment.
-      iexBasePath: http://localhost:${wiremock.server.port}/
+#      iexBasePath: http://localhost:${wiremock.server.port}/
       finnhubBasePath: http://localhost:${wiremock.server.port}/
 
    apikey: ${token}
@@ -65,7 +65,7 @@ spring:
       username: sa
       password:
    rest:
-      iexBasePath: https://api.iextrading.com/1.0
+#      iexBasePath: https://api.iextrading.com/1.0
       finnhubBasePath: https://finnhub.io/api/v1
    apikey: ${token}
 # set debug to get spring to log the classpath (and other things) on startup

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,9 +28,6 @@ mvc:
      getAllSymbolsPath: /stock/symbol
      getLastTradedPricePath: /quote
 
-#   iex:
-#      getAllSymbolsPath: /iex/symbols
-#      getLastTradedPricePath: /iex/lastTradedPrice
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5
@@ -52,7 +49,6 @@ spring:
       password:
    rest:
       # this points at the local WireMock server in the test environment.
-#      iexBasePath: http://localhost:${wiremock.server.port}/
       finnhubBasePath: http://localhost:${wiremock.server.port}/
 
    apikey: ${token}
@@ -65,7 +61,6 @@ spring:
       username: sa
       password:
    rest:
-#      iexBasePath: https://api.iextrading.com/1.0
       finnhubBasePath: https://finnhub.io/api/v1
    apikey: ${token}
 # set debug to get spring to log the classpath (and other things) on startup

--- a/src/test/java/org/galatea/starter/AppConfigTest.java
+++ b/src/test/java/org/galatea/starter/AppConfigTest.java
@@ -1,11 +1,14 @@
 package org.galatea.starter;
 
+import feign.RequestInterceptor;
 import net.sf.ehcache.Cache;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,7 +60,7 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -45,7 +45,7 @@ public class IexRestControllerTest extends ASpringTest {
     MvcResult result = this.mvc.perform(
             // note that we were are testing the fuse REST end point here, not the IEX end point.
             // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
-            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/stock/symbol")
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/stock/symbol?exchange=US")
                 .accept(MediaType.APPLICATION_JSON_VALUE)) // This url matches the URL in the application.yml settings
         .andExpect(status().isOk())
         // some simple validations, in practice I would expect these to be much more comprehensive.

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -43,10 +43,10 @@ public class IexRestControllerTest extends ASpringTest {
   @Test
   public void testGetSymbolsEndpoint() throws Exception {
     MvcResult result = this.mvc.perform(
-        // note that we were are testing the fuse REST end point here, not the IEX end point.
-        // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols")
-            .accept(MediaType.APPLICATION_JSON_VALUE))
+            // note that we were are testing the fuse REST end point here, not the IEX end point.
+            // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         // some simple validations, in practice I would expect these to be much more comprehensive.
         .andExpect(jsonPath("$[0].symbol", is("A")))
@@ -59,11 +59,11 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetLastTradedPrice() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=FB")
-            // This URL will be hit by the MockMvc client. The result is configured in the file
-            // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-            .accept(MediaType.APPLICATION_JSON_VALUE))
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/lastTradedPrice?symbols=FB")
+                // This URL will be hit by the MockMvc client. The result is configured in the file
+                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+                .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
         .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
@@ -74,9 +74,9 @@ public class IexRestControllerTest extends ASpringTest {
   public void testGetLastTradedPriceEmpty() throws Exception {
 
     MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=")
-            .accept(MediaType.APPLICATION_JSON_VALUE))
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/lastTradedPrice?symbols=")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$", is(Collections.emptyList())))
         .andReturn();

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -66,7 +66,7 @@ public class IexRestControllerTest extends ASpringTest {
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.34")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
         .andReturn();
   }
 

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -65,7 +65,7 @@ public class IexRestControllerTest extends ASpringTest {
                 // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
                 .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("c").value(246.2502))
+        .andExpect(jsonPath("$[0].c").value(246.2502))
         .andReturn();
   }
 
@@ -74,7 +74,7 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                .get("/iex/lastTradedPrice?symbols=")
+                .get("/quote?symbol=")
                 .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$", is(Collections.emptyList())))

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -45,13 +45,13 @@ public class IexRestControllerTest extends ASpringTest {
     MvcResult result = this.mvc.perform(
             // note that we were are testing the fuse REST end point here, not the IEX end point.
             // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
-            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols")
-                .accept(MediaType.APPLICATION_JSON_VALUE))
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/stock/symbol")
+                .accept(MediaType.APPLICATION_JSON_VALUE)) // This url matches the URL in the application.yml settings
         .andExpect(status().isOk())
         // some simple validations, in practice I would expect these to be much more comprehensive.
-        .andExpect(jsonPath("$[0].symbol", is("A")))
-        .andExpect(jsonPath("$[1].symbol", is("AA")))
-        .andExpect(jsonPath("$[2].symbol", is("AAAU")))
+        .andExpect(jsonPath("$[0].symbol", is("CNGKY")))
+        .andExpect(jsonPath("$[1].symbol", is("FLOW")))
+        .andExpect(jsonPath("$[0].currency", is("USD")))
         .andReturn();
   }
 
@@ -60,13 +60,12 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                .get("/iex/lastTradedPrice?symbols=FB")
+                .get("/quote?symbol=FB")
                 // This URL will be hit by the MockMvc client. The result is configured in the file
                 // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
                 .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
+        .andExpect(jsonPath("c").value(246.2502))
         .andReturn();
   }
 

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,12 +2,28 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
-    "url" : "/tops/last?symbols=FB",
-    "method" : "GET"
+    "url" : "/tops/last",
+    "method" : "GET",
+    "queryParameters": {
+      "token": {
+        "equalTo": "SecretAPIKEY"
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
+    "jsonBody" : [
+      {
+        "c": 246.2502,
+        "d": -3.0898,
+        "dp": -1.2392,
+        "h": 250.18,
+        "l": 246.04,
+        "o": 250.18,
+        "pc": 249.34,
+        "t": 1760637252
+      }
+    ],
     "headers" : {
       "Server" : "nginx",
       "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -9,7 +9,7 @@
         "equalTo": "FB"
       },
       "token": {
-        "equalTo": "SecretAPIKEY"
+        "matches": ".*"
       }
     }
   },

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,7 +2,7 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
-    "url" : "/tops/last?symbols=AAPL",
+    "url" : "/tops/last?symbols=FB",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,11 +2,11 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
-    "url" : "/tops/last?symbols=FB",
+    "url" : "/tops/last?symbols=AAPL",
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
+    "status" : 200,
     "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,9 +2,12 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
-    "url" : "/tops/last",
+    "urlPattern" : "/tops/last.*",
     "method" : "GET",
     "queryParameters": {
+      "symbol" : {
+        "equalTo": "FB"
+      },
       "token": {
         "equalTo": "SecretAPIKEY"
       }

--- a/src/test/resources/wiremock/mappings/mapping-symbols.json
+++ b/src/test/resources/wiremock/mappings/mapping-symbols.json
@@ -2,11 +2,14 @@
   "id": "4dc720df-b9cd-465e-a27e-68ccdb49ef31",
   "name": "ref-data_symbols",
   "request": {
-    "urlPattern": "/ref-data/symbols.*",
+    "urlPattern": "/ref-data/symbol.*",
     "method": "GET",
     "queryParameters": {
+      "exchange" : {
+        "equalTo": "US"
+      },
       "token": {
-        "equalTo": "SecretAPIKEY"
+        "matches": ".*"
       }
     }
   },

--- a/src/test/resources/wiremock/mappings/mapping-symbols.json
+++ b/src/test/resources/wiremock/mappings/mapping-symbols.json
@@ -3,34 +3,39 @@
   "name": "ref-data_symbols",
   "request": {
     "url": "/ref-data/symbols",
-    "method": "GET"
+    "method": "GET",
+    "queryParameters": {
+      "token": {
+        "equalTo": "SecretAPIKEY"
+      }
+    }
   },
   "response": {
     "status": 200,
     "jsonBody": [
       {
-        "symbol": "A",
-        "name": "Agilent Technologies Inc.",
-        "date": "2019-08-08",
-        "isEnabled": true,
-        "type": "cs",
-        "iexId": "2"
+        "currency": "USD",
+        "description": "CK ASSET HOLDINGS LTD-ADR",
+        "displaySymbol": "CNGKY",
+        "figi": "BBG00B0M9VG1",
+        "isin": null,
+        "mic": "OOTC",
+        "shareClassFIGI": "BBG00B0M9W51",
+        "symbol": "CNGKY",
+        "symbol2": "",
+        "type": "ADR"
       },
       {
-        "symbol": "AA",
-        "name": "Alcoa Corporation",
-        "date": "2019-08-08",
-        "isEnabled": true,
-        "type": "cs",
-        "iexId": "12042"
-      },
-      {
-        "symbol": "AAAU",
-        "name": "Perth Mint Physical Gold ETF",
-        "date": "2019-08-08",
-        "isEnabled": true,
-        "type": "N/A",
-        "iexId": "14924"
+        "currency": "USD",
+        "description": "GLOBAL X US CF KINGS 100 ETF",
+        "displaySymbol": "FLOW",
+        "figi": "BBG01H7RNK95",
+        "isin": null,
+        "mic": "ARCX",
+        "shareClassFIGI": "BBG01H7RNL57",
+        "symbol": "FLOW",
+        "symbol2": "",
+        "type": "ETP"
       }
     ],
     "headers": {

--- a/src/test/resources/wiremock/mappings/mapping-symbols.json
+++ b/src/test/resources/wiremock/mappings/mapping-symbols.json
@@ -2,7 +2,7 @@
   "id": "4dc720df-b9cd-465e-a27e-68ccdb49ef31",
   "name": "ref-data_symbols",
   "request": {
-    "url": "/ref-data/symbols",
+    "urlPattern": "/ref-data/symbols.*",
     "method": "GET",
     "queryParameters": {
       "token": {


### PR DESCRIPTION
# Issue 2: Switch API from IEX to Finnhub API
Goals:
- Change getAllSymbols to hit this endpoint: https://finnhub.io/docs/api/stock-symbols
- Change getLastTrade to hit this endpoint: https://finnhub.io/docs/api/quote

## Major Changes:
### API Key
- Stored as environment variable in IntelliJ under "token"
- Referenced as "apikey" in _application.yml_
#### ApiKeyRequestInterceptor.java
- Added a request interceptor to inject API key into query
#### AppConfig.java
- References apikey, added a call to RequestInterceptor

### Tests
- Updated tests for fuse REST end points utilizing Wiremock
- Fetched mock data from Finnhub API via Postman
- Currently not testing for the optional filtering parameters

### getAllSymbols()
- Updated for required parameter "exchange" and optional parameters (mic, figi, currency). See FinnhubAPI documentation
- Updated to link to /stock/symbol

### getLastTradedPrice()
- Updated to link to /quote
- Minor renaming from "symbols" to "symbol", and vice versa.